### PR TITLE
Add django-oauth-toolkit and django-cors-headers dependency for OAuth2

### DIFF
--- a/ansible/roles/rb-virtualenv/files/requirements.txt
+++ b/ansible/roles/rb-virtualenv/files/requirements.txt
@@ -4,3 +4,5 @@ nose
 p4python
 Sphinx
 subvertpy
+django-oauth-toolkit 
+django-cors-headers


### PR DESCRIPTION
This is a part of the effort adding OAuth2 support to webapi of ReviewBoard
- django-oauth-toolkit contains OAuth2 logic, endpoints and templates
- django-cors-headers allows other service to make request to ReviewBoard
